### PR TITLE
Adding support for chunked transfers

### DIFF
--- a/src/main/scala/org/caoilte/spray/routing/LogAccessRouting.scala
+++ b/src/main/scala/org/caoilte/spray/routing/LogAccessRouting.scala
@@ -93,7 +93,9 @@ class RequestAccessLogger(ctx: RequestContext, accessLogger: AccessLogger,
     case confirmed@(Confirmed(ChunkedMessageEnd, _) | ChunkedMessageEnd) => {
       // Handled like HttpResponse: provide the (previously saved) ChunkedResponseStart for logging and quit
       cancellable.cancel()
-      accessLogger.logAccess(request, chunkedResponse.get, timeStampCalculator(Unit))
+      accessLogger.logAccess(request, chunkedResponse.getOrElse({
+        log.warning(s"Never received a ChunkedResponseStart before this '$confirmed' - thus returning NULL to AccessLogger '$accessLogger'")
+        null}), timeStampCalculator(Unit))
       forwardMsgAndStop(confirmed)
     }
 

--- a/src/test/scala/org/caoilte/spray/routing/LogAccessRoutingDemo.scala
+++ b/src/test/scala/org/caoilte/spray/routing/LogAccessRoutingDemo.scala
@@ -5,7 +5,7 @@ import akka.io.{Tcp, IO}
 import spray.can.Http
 import scala.concurrent.{Await, Future}
 import akka.pattern.ask
-import spray.http.{HttpResponse, HttpRequest}
+import spray.http.{ChunkedResponseStart, ChunkedMessageEnd, HttpResponse, HttpRequest}
 import com.typesafe.config.ConfigFactory
 import akka.util.Timeout
 import scala.concurrent.duration._


### PR DESCRIPTION
Chunked transfers are not handled properly and time out while the transfer is still ongoing.

With this patchset, each messageChunk is considered a heart beat and resetting the timeout scheduler.
